### PR TITLE
render appropriate values for checkboxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,14 @@ Checkbox.prototype.renderOutput = function() {
 /**
  * Render only the selected choices to the terminal
  */
-
 Checkbox.prototype.renderAnswer = function() {
-  var keys = this.choices.checked.map(function(choice) {
-    return typeof choice === 'string' ? choice : choice.value;
-  });
-  return cyan(keys.join(', '));
+  var answers = this.choices.checked.map(function(choice) {
+    if (typeof choice === 'string') {
+      return this.choices.get(choice, 'value') || choice;
+    }
+    return choice.value;
+  }, this);
+  return cyan(answers.join(', '));
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Checkbox() {
   debug('initializing from <%s>', __filename);
   Prompt.apply(this, arguments);
   this.errorMessage = null;
-  this.infoMessage = this.options.infoMessage || '(Press '
+  this.helpMessage = this.options.helpMessage || '(Press '
     + cyan('<space>')
     + ' to toggle)';
 }


### PR DESCRIPTION
With the change to https://github.com/enquirer/prompt-choices/pull/3
We'll should display the appropriate answer for checkboxes.
If the user is using the new version of prompt-choices, we definitely render a list of values.
If the user is using an old version, we still try to fallback to older behavior.  I guess its possible that the value of one question could be a key as a rare edge case, so not too sure how to deal with this completely.